### PR TITLE
Adding in error information to the query client

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -6,7 +6,7 @@ module NhtsaVin
 
     NHTSA_URL = 'https://vpic.nhtsa.dot.gov/api/vehicles/decodevin/'.freeze
 
-    attr_reader :vin, :url, :response, :data
+    attr_reader :vin, :url, :response, :data, :error, :error_code
 
     def initialize(vin, options={})
       @vin = vin
@@ -32,7 +32,14 @@ module NhtsaVin
       # 6 - Incomplete VIN.
       # 8 - No detailed data available currently.
       # 11- Incorrect Model Year, decoded data may not be accurate!
-      @valid = (value_id_for('Error Code').to_i < 4) ? true : false
+      @error_code = value_id_for('Error Code')&.to_i
+
+      @valid = (@error_code < 4) ? true : false
+
+      if @error_code != 0
+        @error = value_for('Error Code')
+      end
+
       return nil unless valid?
 
       make = value_for('Make').capitalize

--- a/spec/lib/nhtsa_vin/query_spec.rb
+++ b/spec/lib/nhtsa_vin/query_spec.rb
@@ -6,10 +6,6 @@ describe NhtsaVin::Query do
   let(:success_response) { File.read(File.join('spec', 'fixtures', 'success.json')) }
   let(:not_found_response) { File.read(File.join('spec', 'fixtures', 'not_found.json')) }
 
-  # let(:xml_error)  { File.read(File.join('spec', 'fixtures', 'error.xml')) }
-  # let(:xml_multi)  { File.read(File.join('spec', 'fixtures', 'success_multi.xml')) }
-  # let(:xml_single) { File.read(File.join('spec', 'fixtures', 'success_single.xml')) }
-
   describe '#initialize' do
     it 'stores the complete URL of the request' do
       expect(client.url)
@@ -27,7 +23,12 @@ describe NhtsaVin::Query do
         expect(client.response).to eq success_response
         expect(client.valid?).to be true
       end
-
+      it 'has no error' do
+        expect(client.error).to be_nil
+      end
+      it 'has an error code of 0' do
+        expect(client.error_code).to eq 0
+      end
       context 'its response' do
         let(:response) { client.get }
         it 'returns a struct' do
@@ -40,7 +41,7 @@ describe NhtsaVin::Query do
           expect(response.body_style).to eq 'Wagon'
           expect(response.doors).to eq 4
         end
-        it 'parses out the type' do
+        it 'parses out the type enumeration' do
           expect(response.type).to eq 'Minivan'
         end
       end
@@ -57,6 +58,12 @@ describe NhtsaVin::Query do
       end
       it 'returns nil' do
         expect(client.get).to be_nil
+      end
+      it 'has an error message' do
+        expect(client.error).to eq '11- Incorrect Model Year, decoded data may not be accurate!'
+      end
+      it 'has an error code' do
+        expect(client.error_code).to eq 11
       end
     end
   end


### PR DESCRIPTION
Now, when the request to the webservice is successful but has errors, we'll include those for the caller. 

```ruby
query = NhtsaVin.get('BAD_VIN_NUMBER')
query.valid? # => false
query.error # => '11- Incorrect Model Year, decoded data may not be accurate!'
query.error_code # => 11
```