### PR TITLE
Adding in network related errors, increasing code coverage

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -15,6 +15,7 @@ module NhtsaVin
 
     def get
       @raw_response = fetch
+      return if @raw_response.nil?
       parse(JSON.parse(@raw_response))
     end
 
@@ -90,7 +91,15 @@ module NhtsaVin
       end
 
       def fetch
-        Net::HTTP.get(URI.parse(@url))
+        begin
+          Net::HTTP.get(URI.parse(@url))
+        rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, SocketError,
+               Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
+               Net::ProtocolError, Errno::ECONNREFUSED => e
+          @valid = false
+          @error = e.message
+          nil
+        end
       end
 
   end

--- a/lib/nhtsa_vin/version.rb
+++ b/lib/nhtsa_vin/version.rb
@@ -1,3 +1,3 @@
 module NhtsaVin
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'.freeze
 end


### PR DESCRIPTION
As mentioned in #6, we weren't handling errors very gracefully. This improves that by wrapping the `Net::HTTP.get` in a rescue, and cleaning up when things go wrong. 

Also, while in the rspec file, I've added a few more examples. 