### PR TITLE
Adding in VIN validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,34 @@ Or install it yourself as:
 
     gem install nhsta_vin
 
-## Usage
+## Usage 
 
-Usage is fairly simple, there's an exposed `get` class method that you can pass in a VIN string to, and it will return you a NhtsaVin::Query.  
+Validation
+----
+
+Prior to dispatching a call to the web service, you can optionally validate a given VIN first. 
+
+```ruby
+validation = NhtsaVin.Validate.new('1J4BA5H11AL143811') # => <#NhtsaVin.Validate>
+validation.valid? # => true
+validation.checksum # => 1
+
+validation = NhtsaVin.Validate.new('SOMEBADVIN') # => <#NhtsaVin.Validate>
+validation.valid? # => false
+validation.checksum # => nil
+```
+
+Query
+----
+
+The main method for the gem is `NhtsaVin::get`, which takes a VIN string as the argument, and will return you a NhtsaVin::Query.  
 
 ```ruby
 query = NhtsaVin.get('1J4BA5H11AL143811') # => <NhtsaVin::Query>
 query.valid? # => true
 ```
 
-The actual data from the webservice is contained in the `response` method. This returns a struct containing the various interesting bits from the API.
+The actual data from the web service is contained in the `response` method. This returns a struct containing the various interesting bits from the API.
 
 ```ruby
 query.response # => <Struct::NhtsaResponse make="Jeep", model="Grand Cherokee", trim="Laredo/Rocky Mountain Edition", type="SUV", year="2008", size=nil, ... doors=4>

--- a/lib/nhtsa_vin.rb
+++ b/lib/nhtsa_vin.rb
@@ -1,5 +1,6 @@
 require 'nhtsa_vin/version'
 require 'nhtsa_vin/query'
+require 'nhtsa_vin/validation'
 
 module NhtsaVin
   extend self
@@ -7,7 +8,6 @@ module NhtsaVin
   def get(vin, options={})
     query = NhtsaVin::Query.new(vin, options)
     query.get
-
     return query
   end
 end

--- a/lib/nhtsa_vin/validation.rb
+++ b/lib/nhtsa_vin/validation.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module NhtsaVin
+  class Validation
+    TRANSLITERATIONS = { 'A': 1, 'B': 2, 'C': 3, 'D': 4, 'E': 5, 'F': 6, 'G': 7,
+                         'H': 8, 'J': 1, 'K': 2, 'L': 3, 'M': 4, 'N': 5, 'P': 7,
+                         'R': 9, 'S': 2, 'T': 3, 'U': 4, 'V': 5, 'W': 6, 'X': 7,
+                         'Y': 8, 'Z': 9 }.freeze
+
+    WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
+
+    attr_reader :vin, :valid, :wmi, :vds, :check, :plant, :seq, :error
+
+    ##
+    # Validates a VIN that it fits both the definition, and that the checksum
+    # is valid.
+    #
+    def initialize(vin)
+      @valid = false
+      if vin.nil?
+        @error = 'Blank VIN provided'
+        return
+      end
+      @vin = vin.strip
+      if !regex
+        @error = 'Invalid VIN format'
+        return
+      elsif checksum != @check
+        @error = "VIN checksum digit #{@check} failed "\
+                 "to calculate (expected #{checksum})"
+        return
+      else
+        @valid = true
+      end
+    end
+
+    def valid?
+      @valid
+    end
+
+    private
+
+    def regex
+      match_data = %r{
+        ^(?<wmi>[A-HJ-NPR-Z\d]{3})
+         (?<vds>[A-HJ-NPR-Z\d]{5})
+         (?<check>[\dX])
+         (?<vis>(?<year>[A-HJ-NPR-Z\d])
+         (?<plant>[A-HJ-NPR-Z\d])
+         (?<seq>[A-HJ-NPR-Z\d]{6}))$
+      }ix.match(@vin)
+
+      if match_data
+        @wmi = match_data[:wmi]
+        @vds = match_data[:vds]
+        @check = match_data[:check]
+        @vis = match_data[:vis]
+        @plant = match_data[:plant]
+        @seq = match_data[:seq]
+      end
+      match_data
+    end
+
+    def checksum
+      m = @vin.chars.each_with_index.map do |char, i|
+        if char !~ /\D/
+          char.to_i * WEIGHTS[i]
+        else
+          TRANSLITERATIONS[char.upcase.to_sym] * WEIGHTS[i]
+        end
+      end
+      checksum = m.inject(0, :+) % 11
+      checksum == 10 ? 'X' : checksum.to_s
+    end
+  end
+end

--- a/spec/lib/nhtsa_vin/validation_spec.rb
+++ b/spec/lib/nhtsa_vin/validation_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe NhtsaVin::Validation do
+  describe 'attrs' do
+    context 'with a valid VIN' do
+      let(:validation) { NhtsaVin::Validation.new('19XFB2F89CE308518') }
+      it 'has the checksum digit' do
+        expect(validation.check).to eq '9'
+      end
+      it 'parses out the WMI' do
+        expect(validation.wmi).to eq '19X'
+      end
+      it 'parses out the plant ID' do
+        expect(validation.plant).to eq 'E'
+      end
+      it 'parses out the sequence info' do
+        expect(validation.seq).to eq '308518'
+      end
+    end
+    context 'with an invalid VIN' do
+      let(:validation) { NhtsaVin::Validation.new('WBAEV534X2KM1611') }
+      it 'has nil attrs' do
+        expect(validation.check).to be_nil
+        expect(validation.wmi).to be_nil
+        expect(validation.plant).to be_nil
+        expect(validation.seq).to be_nil
+      end
+    end
+  end
+  describe '#valid?' do
+    context 'a valid VIN' do
+      it 'validates' do
+        expect(NhtsaVin::Validation.new('19XFB2F89CE308518').valid?)
+          .to be true
+      end
+      it 'handles checksums of 10' do
+        expect(NhtsaVin::Validation.new('5NPEU46FX6H141974').valid?)
+          .to be true
+      end
+      it 'strips whitespace' do
+        expect(NhtsaVin::Validation.new(' 4T1BD1FK5CU061770  ').valid?)
+          .to be true
+      end
+      it 'validates BMW VINs' do
+        expect(NhtsaVin::Validation.new('WBAEV534X2KM16113').valid?)
+          .to be true
+      end
+    end
+    context 'an invalid VIN' do
+      context 'when the vin is too short' do
+        let(:validation) { NhtsaVin::Validation.new('WBAEV534X2KM1611') }
+        it 'fails' do
+          expect(validation.valid?).to be false
+          expect(validation.error).to eq 'Invalid VIN format'
+        end
+      end
+      context 'when the vin contains O' do
+        let(:validation) { NhtsaVin::Validation.new('WBAEV534X2KM1611O') }
+        it 'fails' do
+          expect(NhtsaVin).not_to receive(:checksum)
+          expect(validation.valid?).to be false
+          expect(validation.error).to eq 'Invalid VIN format'
+        end
+      end
+      context 'when the vin contains I' do
+        let(:validation) { NhtsaVin::Validation.new('WBAEV534X2KM1611I') }
+        it 'fails' do
+          expect(NhtsaVin).not_to receive(:checksum)
+          expect(validation.valid?).to be false
+          expect(validation.error).to eq 'Invalid VIN format'
+        end
+      end
+      context 'fails when the vin contains Q' do
+        let(:validation) { NhtsaVin::Validation.new('WBAEV534X2KM1611Q') }
+        it 'fails' do
+          expect(NhtsaVin).not_to receive(:checksum)
+          expect(validation.valid?).to be false
+          expect(validation.error).to eq 'Invalid VIN format'
+        end
+      end
+      context 'when the checksum is incorrect' do
+        let(:validation) { NhtsaVin::Validation.new('5NPEU46F96H141974') }
+        it 'fails' do
+          expect(validation.valid?).to be false
+          expect(validation.error)
+            .to eq 'VIN checksum digit 9 failed to calculate (expected X)'
+        end
+      end
+      context 'when the vin is nil' do
+        let(:validation) { NhtsaVin::Validation.new(nil) }
+        it 'fails' do
+          expect(validation.valid?).to be false
+          expect(validation.error).to eq 'Blank VIN provided'
+        end
+      end
+      context 'when high-ascii chars are used' do
+        it 'fails' do
+          expect(NhtsaVin::Validation.new('∂BAEV534X2KM16113').valid?)
+            .to be false
+          expect(NhtsaVin::Validation.new('🥃BAEV534X2KM16113').valid?)
+            .to be false
+          expect(NhtsaVin::Validation.new('WBAEV534X2KM1611').error)
+            .to eq 'Invalid VIN format'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding in basic VIN validation. 

Now, prior to calling the web service, we can now validate it first. 

```ruby
validation = NhtsaVin.Validate.new('1J4BA5H11AL143811') # => <#NhtsaVin.Validation>
validation.valid? # => true
validation.checksum # => 1

validation = NhtsaVin.Validate.new('SOMEBADVIN') # => <#NhtsaVin.Validation>
validation.valid? # => false
validation.checksum # => nil
```

This was heavily cribbed from @ramaboo-deliv's original PHP stuff (thanks david!)