### PR TITLE
[ch5614] Upcase VIN before validation and query

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -9,7 +9,7 @@ module NhtsaVin
     attr_reader :vin, :url, :response, :data, :error, :error_code, :raw_response
 
     def initialize(vin, options={})
-      @vin = vin
+      @vin = vin.strip.upcase
       @http_options = options[:http] || {}
       build_url
     end

--- a/lib/nhtsa_vin/validation.rb
+++ b/lib/nhtsa_vin/validation.rb
@@ -21,7 +21,7 @@ module NhtsaVin
         @error = 'Blank VIN provided'
         return
       end
-      @vin = vin.strip
+      @vin = vin.strip.upcase
       if !regex
         @error = 'Invalid VIN format'
         return

--- a/spec/lib/nhtsa_vin/validation_spec.rb
+++ b/spec/lib/nhtsa_vin/validation_spec.rb
@@ -41,6 +41,10 @@ describe NhtsaVin::Validation do
         expect(NhtsaVin::Validation.new(' 4T1BD1FK5CU061770  ').valid?)
           .to be true
       end
+      it 'converts to uppercase' do
+        expect(NhtsaVin::Validation.new('4t1bd1fk5cu061770').valid?)
+          .to be true
+      end
       it 'validates BMW VINs' do
         expect(NhtsaVin::Validation.new('WBAEV534X2KM16113').valid?)
           .to be true


### PR DESCRIPTION
Validation was failing even though NHTSA API doesn't require the VIN to be upper case. This PR simply converts the VIN to upper case. Added a spec for this as well. 