### PR TITLE
Fix for passing HTTP/SSL options.

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -101,11 +101,7 @@ module NhtsaVin
           @valid = false
 
           url = URI.parse(@url)
-          Net::HTTP.start(url.host, url.port, use_ssl: (url.scheme == 'https')) do |http|
-            @http_options.each do |key, val|
-              http.send("#{key}=", val) if val
-            end
-
+          Net::HTTP.start(url.host, url.port, { use_ssl: (url.scheme == 'https') }.merge(@http_options)) do |http|
             resp = http.request_get(url)
             case resp
             when Net::HTTPSuccess

--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -101,7 +101,9 @@ module NhtsaVin
           @valid = false
 
           url = URI.parse(@url)
-          Net::HTTP.start(url.host, url.port, { use_ssl: (url.scheme == 'https') }.merge(@http_options)) do |http|
+          http_options = { use_ssl: (url.scheme == 'https') }
+          http_options.update(@http_options)
+          Net::HTTP.start(url.host, url.port, http_options) do |http|
             resp = http.request_get(url)
             case resp
             when Net::HTTPSuccess


### PR DESCRIPTION
NHTSA's SSL certificate expired at 11:30 this morning, which demonstrated that my attempt to disable SSL verification wasn't working.  This should fix it.