### PR TITLE
Handle nil JSON responses

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -16,9 +16,9 @@ module NhtsaVin
 
     def get
       @raw_response = fetch
-      return if @raw_response.nil?
       begin
-        parse(JSON.parse(@raw_response))
+        return if @raw_response.nil? || (json_response = JSON.parse(@raw_response)).nil?
+        parse(json_response)
       rescue JSON::ParserError
         @valid = false
         @error = 'Response is not valid JSON'


### PR DESCRIPTION
I noticed some requests throwing an exception of `undefined method `[]' for nil:NilClass`.  I can't replicate this in development, but I noticed that it is possible for `@raw_response` to be not-nil, while `JSON.parse` returns `nil` (e.g. if the response json is `null`).  This change should handle that case, and ensure that all network errors are catchable.