### PR TITLE
Handle timeout responses

### DIFF
--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -32,6 +32,11 @@ module NhtsaVin
     end
 
     def parse(json)
+      if json['Message']&.match /execution error/i
+        @valid = false
+        @error = json.dig('Results', 0, 'Message')
+        return
+      end
       @data = json['Results']
 
       # 0 - Good

--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -22,7 +22,7 @@ module NhtsaVin
       rescue JSON::ParserError
         @valid = false
         @error = 'Response is not valid JSON'
-      rescue => ex
+      rescue StandardError => ex
         raise "#{ex.message}: #{@raw_response.inspect}"
       end
     end
@@ -32,7 +32,7 @@ module NhtsaVin
     end
 
     def parse(json)
-      if json['Message']&.match /execution error/i
+      if json['Message']&.match(/execution error/i)
         @valid = false
         @error = json.dig('Results', 0, 'Message')
         return

--- a/lib/nhtsa_vin/query.rb
+++ b/lib/nhtsa_vin/query.rb
@@ -22,6 +22,8 @@ module NhtsaVin
       rescue JSON::ParserError
         @valid = false
         @error = 'Response is not valid JSON'
+      rescue => ex
+        raise "#{ex.message}: #{@raw_response.inspect}"
       end
     end
 

--- a/spec/lib/nhtsa_vin/query_spec.rb
+++ b/spec/lib/nhtsa_vin/query_spec.rb
@@ -78,6 +78,16 @@ describe NhtsaVin::Query do
         expect(client.error).to eq 'Response is not valid JSON'
       end
     end
+    context 'timeout response' do
+      before do
+        allow(client).to receive(:fetch).and_return('{"Count":0,"Message":"Execution Error","SearchCriteria":null,"Results":[{"Message":"Error encountered retrieving data: Connection Timeout Expired.  The timeout period elapsed while attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login handshake failed or the server was unable to respond back in time.  The duration spent while attempting to connect to this server was - [Pre-Login] initialization=6; handshake=14988; "}]}')
+        client.get
+      end
+      it 'is not valid' do
+        expect(client).not_to be_valid
+        expect(client.error).to match /connection timeout expired/i
+      end
+    end
     context 'HTTP error' do
       it '5xx' do
         resp = Net::HTTPServerError.new(1.1, 503, 'Service unhappy')

--- a/spec/lib/nhtsa_vin/query_spec.rb
+++ b/spec/lib/nhtsa_vin/query_spec.rb
@@ -85,7 +85,7 @@ describe NhtsaVin::Query do
       end
       it 'is not valid' do
         expect(client).not_to be_valid
-        expect(client.error).to match /connection timeout expired/i
+        expect(client.error).to match(/connection timeout expired/i)
       end
     end
     context 'HTTP error' do


### PR DESCRIPTION
Finally found the error response I keep seeing in production (looks like an internal loadbalancer error).  Added check and specs, tried to keep it conservative (the exception was coming from `valid_id_for`, when `get_row` returns `nil`)